### PR TITLE
Require Roundcube >= 1.3.0, PHP >=5.4 and apply some coding standard cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.php]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 .gitignore export-ignore
 .gitattributes export-ignore
+.editorconfig export-ignore

--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ Inspired by [roundcube-easy-unsubscribe](https://github.com/SS88UK/roundcube-eas
 The [composer library](https://packagist.org/packages/germancoding/tls_icon) name is: `germancoding/tls_icon`.
 
 The plugin name to add to your config file is: `tls_icon`.
+
+## Requirements
+
+- Roundcube `1.3.0` or newer.
+- PHP `5.4` or newer.

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,17 @@
         }
     ],
     "require": {
-        "roundcube/plugin-installer": ">=0.1.6"
+        "php": "^5.4 || ^7.0 || ^8.0",
+        "roundcube/plugin-installer": "^0.3.2"
     },
     "config": {
         "allow-plugins": {
             "roundcube/plugin-installer": true
+        }
+    },
+    "extra": {
+        "roundcube": {
+            "min-version": "1.3.0"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^5.4 || ^7.0 || ^8.0",
-        "roundcube/plugin-installer": "^0.1.6"
+        "roundcube/plugin-installer": ">=0.1.6"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^5.4 || ^7.0 || ^8.0",
-        "roundcube/plugin-installer": "^0.3.2"
+        "roundcube/plugin-installer": "^0.1.6"
     },
     "config": {
         "allow-plugins": {

--- a/tls_icon.php
+++ b/tls_icon.php
@@ -22,12 +22,11 @@ class tls_icon extends rcube_plugin
 	function get_received_header_content($Received_Header)
 	{
 		$Received = null;
-		if(is_array($Received_Header)) {
+		if (is_array($Received_Header)) {
 			$ignore_n_hops = $this->rcmail->config->get('tls_icon_ignore_hops');
-			if($ignore_n_hops && count($Received_Header) > $ignore_n_hops) {
+			if ($ignore_n_hops && count($Received_Header) > $ignore_n_hops) {
 				$Received = $Received_Header[$ignore_n_hops];
-			}
-			else {
+			} else {
 				$Received = $Received_Header[0];
 			}
 		} else {
@@ -38,47 +37,44 @@ class tls_icon extends rcube_plugin
 
 	public function storage_init($p)
 	{
-		$p['fetch_headers'] = trim(($p['fetch_headers']?? '') . ' ' . strtoupper('Received'));
+		$p['fetch_headers'] = trim(($p['fetch_headers'] ?? '') . ' ' . strtoupper('Received'));
 		return $p;
 	}
 
 	public function message_headers($p)
 	{
-		if($this->message_headers_done===false)
-		{
+		if ($this->message_headers_done === false) {
 			$this->message_headers_done = true;
 
 			$Received_Header = $p['headers']->others['received'] ?? null;
 			$Received = $this->get_received_header_content($Received_Header);
 
-			if($Received == null) {
+			if ($Received == null) {
 				// There was no Received Header. Possibly an outbound mail. Do nothing.
 				return $p;
 			}
 
-			if ( preg_match_all('/\(using TLS.*.*\) \(/im', $Received, $items, PREG_PATTERN_ORDER) ) {
+			if (preg_match_all('/\(using TLS.*.*\) \(/im', $Received, $items, PREG_PATTERN_ORDER)) {
 				$data = $items[0][0];
 
-				$needle = "(using ";
+				$needle = '(using ';
 				$pos = strpos($data, $needle);
-				$data = substr_replace($data, "", $pos, strlen($needle));
+				$data = substr_replace($data, '', $pos, strlen($needle));
 
-				$needle = ") (";
+				$needle = ') (';
 				$pos = strrpos($data, $needle);
-				$data = substr_replace($data, "", $pos, strlen($needle));
+				$data = substr_replace($data, '', $pos, strlen($needle));
 
-				$this->icon_img .= '<img class="lock_icon" src="plugins/tls_icon/lock.svg" title="'. htmlentities($data) .'" />';
-			} else if(preg_match_all('/\([a-zA-Z]*, from userid [0-9]*\)/im', $Received, $items, PREG_PATTERN_ORDER)){
+				$this->icon_img .= '<img class="lock_icon" src="plugins/tls_icon/lock.svg" title="' . htmlentities($data) . '" />';
+			} elseif (preg_match_all('/\([a-zA-Z]*, from userid [0-9]*\)/im', $Received, $items, PREG_PATTERN_ORDER)) {
 				$this->icon_img .= '<img class="lock_icon" src="plugins/tls_icon/blue_lock.svg" title="' . $this->gettext('internal') . '" />';
-			}
-			else {
+			} else {
 				// TODO: Mails received from localhost but without TLS are currently flagged insecure
 				$this->icon_img .= '<img class="lock_icon" src="plugins/tls_icon/unlock.svg" title="' . $this->gettext('unencrypted') . '" />';
 			}
 		}
 
-		if(isset($p['output']['subject']))
-		{
+		if (isset($p['output']['subject'])) {
 			$p['output']['subject']['value'] = htmlentities($p['output']['subject']['value']) . $this->icon_img;
 			$p['output']['subject']['html'] = 1;
 		}

--- a/tls_icon.php
+++ b/tls_icon.php
@@ -37,7 +37,8 @@ class tls_icon extends rcube_plugin
 
 	public function storage_init($p)
 	{
-		$p['fetch_headers'] = trim(($p['fetch_headers'] ?? '') . ' ' . strtoupper('Received'));
+		$headers = isset($p['fetch_headers']) ? $p['fetch_headers'] : '';
+		$p['fetch_headers'] = trim($headers) . ' ' . strtoupper('Received');
 		return $p;
 	}
 
@@ -46,7 +47,7 @@ class tls_icon extends rcube_plugin
 		if ($this->message_headers_done === false) {
 			$this->message_headers_done = true;
 
-			$Received_Header = $p['headers']->others['received'] ?? null;
+			$Received_Header = isset($p['headers']->others['received']) ? $p['headers']->others['received'] : null;
 			$Received = $this->get_received_header_content($Received_Header);
 
 			if ($Received == null) {


### PR DESCRIPTION
See: https://github.com/GermanCoding/Roundcube_TLS_Icon/discussions/6

I applied https://github.com/wdes/coding-standard and removed some changes. So we only have the coherent file aspect. Some spaces and syntax where not identical in all the file. I made sure the diff stayed minimal

Removed the https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.null-coalesce-op for PHP 5 suppport