### PR TITLE
Support Sendmail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # Roundcube TLS Icon
 
 Displays a small icon after the subject line that displays the (presumed) encryption state of received mails.
-This plugin parses the "Received" header for the last hop and checks if TLS was used. This requires TLS logging in the receiving MTA.
+This plugin parses the "Received" header for the last hop and checks if TLS was used. This requires TLS logging in the
+receiving MTA.
 
-In Postfix this can be enabled by setting [`smtpd_tls_received_header = yes`](https://www.postfix.org/postconf.5.html#smtpd_tls_received_header). The regex used to parse the header has only been tested against Postfix. TODO: Document sendmail support
+In Postfix this can be enabled by
+setting [`smtpd_tls_received_header = yes`](https://www.postfix.org/postconf.5.html#smtpd_tls_received_header). Sendmail
+should work out of the box. Other MTAs have not been explicitly tested.
 
-Note that while this talks about "encryption", this does not imply security. An encrypted mail may still be insecure, mostly because mailservers generally use  "opportunistic TLS", where MITM attacks are possible.
-This also only validates the last hop of an email - some emails may run through multiple hops and we don't know anything about the security of these.
+Note that while this talks about "encryption", this does not imply security. An encrypted mail may still be insecure,
+mostly because mailservers generally use  "opportunistic TLS", where MITM attacks are possible.
+This also only validates the last hop of an email - some emails may run through multiple hops and we don't know anything
+about the security of these.
 
 Inspired by [roundcube-easy-unsubscribe](https://github.com/SS88UK/roundcube-easy-unsubscribe)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Displays a small icon after the subject line that displays the (presumed) encryption state of received mails.
 This plugin parses the "Received" header for the last hop and checks if TLS was used. This requires TLS logging in the receiving MTA.
 
-In Postfix this can be enabled by setting [`smtpd_tls_received_header = yes`](https://www.postfix.org/postconf.5.html#smtpd_tls_received_header). The regex used to parse the header has only been tested against Postfix.
+In Postfix this can be enabled by setting [`smtpd_tls_received_header = yes`](https://www.postfix.org/postconf.5.html#smtpd_tls_received_header). The regex used to parse the header has only been tested against Postfix. TODO: Document sendmail support
 
 Note that while this talks about "encryption", this does not imply security. An encrypted mail may still be insecure, mostly because mailservers generally use  "opportunistic TLS", where MITM attacks are possible.
 This also only validates the last hop of an email - some emails may run through multiple hops and we don't know anything about the security of these.

--- a/test/TlsIconTest.php
+++ b/test/TlsIconTest.php
@@ -343,4 +343,40 @@ final class TlsIconTest extends TestCase
 			]
 		], $headersProcessed);
 	}
+
+	public function testSendmailTLS13MultipleRecipients()
+	{
+		$o = new tls_icon();
+		$headersProcessed = $o->message_headers([
+			'output' => [
+				'subject' => [
+					'value' => 'Sent to you',
+				],
+			],
+			'headers' => (object)[
+				'others' => [
+					'received' => 'from mout.kundenserver.de (mout.kundenserver.de [212.227.126.134])
+					by mail.aegee.org (8.17.1/8.17.1) with ESMTPS id 2BLGrgYw3602565
+					(version=TLSv1.3 cipher=TLS_AES_256_GCM_SHA384 bits=256 verify=NO);
+					Wed, 21 Dec 2022 16:53:42 GMT',
+				]
+			]
+		]);
+		$this->assertEquals([
+			'output' => [
+				'subject' => [
+					'value' => 'Sent to you' . $this->strSendmailCryptedTlsv13WithCipherNoVerify,
+					'html' => 1,
+				],
+			],
+			'headers' => (object)[
+				'others' => [
+					'received' => 'from mout.kundenserver.de (mout.kundenserver.de [212.227.126.134])
+					by mail.aegee.org (8.17.1/8.17.1) with ESMTPS id 2BLGrgYw3602565
+					(version=TLSv1.3 cipher=TLS_AES_256_GCM_SHA384 bits=256 verify=NO);
+					Wed, 21 Dec 2022 16:53:42 GMT',
+				]
+			]
+		], $headersProcessed);
+	}
 }

--- a/test/TlsIconTest.php
+++ b/test/TlsIconTest.php
@@ -24,6 +24,13 @@ final class TlsIconTest extends TestCase
 	/** @var string */
 	private $strInternal = '<img class="lock_icon" src="plugins/tls_icon/blue_lock.svg" title="Mail was internal" />';
 
+	/** @var string */
+	private $strSendmailCryptedTlsv13WithCipherNoVerify = '<img class="lock_icon" src="plugins/tls_icon/lock.svg" title="TLSv1.3 cipher=TLS_AES_256_GCM_SHA384 bits=256 verify=NO" />';
+
+	/** @var string */
+	private $strSendmailCryptedTlsv12WithCipherVerify = '<img class="lock_icon" src="plugins/tls_icon/lock.svg" title="TLSv1.2 cipher=ECDHE-RSA-AES256-GCM-SHA384 bits=256 verify=OK" />';
+
+
 	public function testInstance()
 	{
 		$o = new tls_icon();
@@ -62,7 +69,7 @@ final class TlsIconTest extends TestCase
 					'value' => 'Sent to you',
 				],
 			],
-			'headers' => (object) [
+			'headers' => (object)[
 				'others' => [
 					'received' => 'my header',
 				]
@@ -75,7 +82,7 @@ final class TlsIconTest extends TestCase
 					'html' => 1,
 				],
 			],
-			'headers' => (object) [
+			'headers' => (object)[
 				'others' => [
 					'received' => 'my header',
 				]
@@ -92,7 +99,7 @@ final class TlsIconTest extends TestCase
 					'value' => 'Sent to you',
 				],
 			],
-			'headers' => (object) [
+			'headers' => (object)[
 				'others' => [
 					'received' => 'from smtp.github.com (out-21.smtp.github.com [192.30.252.204])
 					(using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits)) (No client certificate requested)
@@ -108,7 +115,7 @@ final class TlsIconTest extends TestCase
 					'html' => 1,
 				],
 			],
-			'headers' => (object) [
+			'headers' => (object)[
 				'others' => [
 					'received' => 'from smtp.github.com (out-21.smtp.github.com [192.30.252.204])
 					(using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits)) (No client certificate requested)
@@ -128,7 +135,7 @@ final class TlsIconTest extends TestCase
 					'value' => 'Sent to you',
 				],
 			],
-			'headers' => (object) [
+			'headers' => (object)[
 				'others' => [
 					'received' => 'from smtp.github.com (out-21.smtp.github.com [192.30.252.204])
 					(using TLSv1.2) (No client certificate requested)
@@ -144,7 +151,7 @@ final class TlsIconTest extends TestCase
 					'html' => 1,
 				],
 			],
-			'headers' => (object) [
+			'headers' => (object)[
 				'others' => [
 					'received' => 'from smtp.github.com (out-21.smtp.github.com [192.30.252.204])
 					(using TLSv1.2) (No client certificate requested)
@@ -164,7 +171,7 @@ final class TlsIconTest extends TestCase
 					'value' => 'Sent to you',
 				],
 			],
-			'headers' => (object) [
+			'headers' => (object)[
 				'others' => [
 					'received' => 'by aaa.bbb.ccc (Postfix, from userid 0)
 					id A70248414D5; Sun, 26 Apr 2020 16:49:01 +0200 (CEST)',
@@ -178,7 +185,7 @@ final class TlsIconTest extends TestCase
 					'html' => 1,
 				],
 			],
-			'headers' => (object) [
+			'headers' => (object)[
 				'others' => [
 					'received' => 'by aaa.bbb.ccc (Postfix, from userid 0)
 					id A70248414D5; Sun, 26 Apr 2020 16:49:01 +0200 (CEST)',
@@ -205,7 +212,7 @@ final class TlsIconTest extends TestCase
 					'value' => 'Sent to you',
 				],
 			],
-			'headers' => (object) [
+			'headers' => (object)[
 				'others' => [
 					'received' => $inputHeaders,
 				]
@@ -218,7 +225,7 @@ final class TlsIconTest extends TestCase
 					'html' => 1,
 				],
 			],
-			'headers' => (object) [
+			'headers' => (object)[
 				'others' => [
 					'received' => $inputHeaders,
 				]
@@ -244,7 +251,7 @@ final class TlsIconTest extends TestCase
 					'value' => 'Sent to you',
 				],
 			],
-			'headers' => (object) [
+			'headers' => (object)[
 				'others' => [
 					'received' => $inputHeaders,
 				]
@@ -257,9 +264,81 @@ final class TlsIconTest extends TestCase
 					'html' => 1,
 				],
 			],
-			'headers' => (object) [
+			'headers' => (object)[
 				'others' => [
 					'received' => $inputHeaders,
+				]
+			]
+		], $headersProcessed);
+	}
+
+	public function testSendmailTLS13NoVerify()
+	{
+		$o = new tls_icon();
+		$headersProcessed = $o->message_headers([
+			'output' => [
+				'subject' => [
+					'value' => 'Sent to you',
+				],
+			],
+			'headers' => (object)[
+				'others' => [
+					'received' => 'from 69-171-232-143.mail-mail.facebook.com (69-171-232-143.mail-mail.facebook.com [69.171.232.143])
+					by mail.aegee.org (8.17.1/8.17.1) with ESMTPS id 2BI73F8b1489360
+					(version=TLSv1.3 cipher=TLS_AES_256_GCM_SHA384 bits=256 verify=NO)
+					for <my@address>; Sun, 18 Dec 2022 07:03:16 GMT',
+				]
+			]
+		]);
+		$this->assertEquals([
+			'output' => [
+				'subject' => [
+					'value' => 'Sent to you' . $this->strSendmailCryptedTlsv13WithCipherNoVerify,
+					'html' => 1,
+				],
+			],
+			'headers' => (object)[
+				'others' => [
+					'received' => 'from 69-171-232-143.mail-mail.facebook.com (69-171-232-143.mail-mail.facebook.com [69.171.232.143])
+					by mail.aegee.org (8.17.1/8.17.1) with ESMTPS id 2BI73F8b1489360
+					(version=TLSv1.3 cipher=TLS_AES_256_GCM_SHA384 bits=256 verify=NO)
+					for <my@address>; Sun, 18 Dec 2022 07:03:16 GMT',
+				]
+			]
+		], $headersProcessed);
+	}
+
+	public function testSendmailTLS12WithVerify()
+	{
+		$o = new tls_icon();
+		$headersProcessed = $o->message_headers([
+			'output' => [
+				'subject' => [
+					'value' => 'Sent to you',
+				],
+			],
+			'headers' => (object)[
+				'others' => [
+					'received' => 'from smtp.github.com (out-18.smtp.github.com [192.30.252.201])
+					by mail.aegee.org (8.17.1/8.17.1) with ESMTPS id 2BGMf4uY685293
+					(version=TLSv1.2 cipher=ECDHE-RSA-AES256-GCM-SHA384 bits=256 verify=OK)
+					for <my@address>; Fri, 16 Dec 2022 22:41:05 GMT',
+				]
+			]
+		]);
+		$this->assertEquals([
+			'output' => [
+				'subject' => [
+					'value' => 'Sent to you' . $this->strSendmailCryptedTlsv12WithCipherVerify,
+					'html' => 1,
+				],
+			],
+			'headers' => (object)[
+				'others' => [
+					'received' => 'from smtp.github.com (out-18.smtp.github.com [192.30.252.201])
+					by mail.aegee.org (8.17.1/8.17.1) with ESMTPS id 2BGMf4uY685293
+					(version=TLSv1.2 cipher=ECDHE-RSA-AES256-GCM-SHA384 bits=256 verify=OK)
+					for <my@address>; Fri, 16 Dec 2022 22:41:05 GMT',
 				]
 			]
 		], $headersProcessed);

--- a/tls_icon.php
+++ b/tls_icon.php
@@ -7,6 +7,7 @@ class tls_icon extends rcube_plugin
 	private $rcmail;
 	private $postfix_tls_regex = "/\(using (TLS.*)\) \(/im";
 	private $postfix_local_regex = "/\([a-zA-Z]*, from userid [0-9]*\)/im";
+	private $sendmail_tls_regex = "/\(version=(TLS.*)\)\s+for/im";
 
 	function init()
 	{
@@ -57,7 +58,8 @@ class tls_icon extends rcube_plugin
 				return $p;
 			}
 
-			if (preg_match_all($this->postfix_tls_regex, $Received, $items, PREG_PATTERN_ORDER)) {
+			if (preg_match_all($this->postfix_tls_regex, $Received, $items, PREG_PATTERN_ORDER) ||
+				preg_match_all($this->sendmail_tls_regex, $Received, $items, PREG_PATTERN_ORDER)) {
 				$data = $items[1][0];
 				$this->icon_img .= '<img class="lock_icon" src="plugins/tls_icon/lock.svg" title="' . htmlentities($data) . '" />';
 			} elseif (preg_match_all($this->postfix_local_regex, $Received, $items, PREG_PATTERN_ORDER)) {

--- a/tls_icon.php
+++ b/tls_icon.php
@@ -5,6 +5,8 @@ class tls_icon extends rcube_plugin
 	private $message_headers_done = false;
 	private $icon_img;
 	private $rcmail;
+	private $postfix_tls_regex = "/\(using (TLS.*)\) \(/im";
+	private $postfix_local_regex = "/\([a-zA-Z]*, from userid [0-9]*\)/im";
 
 	function init()
 	{
@@ -55,19 +57,10 @@ class tls_icon extends rcube_plugin
 				return $p;
 			}
 
-			if (preg_match_all('/\(using TLS.*.*\) \(/im', $Received, $items, PREG_PATTERN_ORDER)) {
-				$data = $items[0][0];
-
-				$needle = '(using ';
-				$pos = strpos($data, $needle);
-				$data = substr_replace($data, '', $pos, strlen($needle));
-
-				$needle = ') (';
-				$pos = strrpos($data, $needle);
-				$data = substr_replace($data, '', $pos, strlen($needle));
-
+			if (preg_match_all($this->postfix_tls_regex, $Received, $items, PREG_PATTERN_ORDER)) {
+				$data = $items[1][0];
 				$this->icon_img .= '<img class="lock_icon" src="plugins/tls_icon/lock.svg" title="' . htmlentities($data) . '" />';
-			} elseif (preg_match_all('/\([a-zA-Z]*, from userid [0-9]*\)/im', $Received, $items, PREG_PATTERN_ORDER)) {
+			} elseif (preg_match_all($this->postfix_local_regex, $Received, $items, PREG_PATTERN_ORDER)) {
 				$this->icon_img .= '<img class="lock_icon" src="plugins/tls_icon/blue_lock.svg" title="' . $this->gettext('internal') . '" />';
 			} else {
 				// TODO: Mails received from localhost but without TLS are currently flagged insecure

--- a/tls_icon.php
+++ b/tls_icon.php
@@ -2,12 +2,13 @@
 
 class tls_icon extends rcube_plugin
 {
+	const POSTFIX_TLS_REGEX = "/\(using (TLS.*)\) \(/im";
+	const POSTFIX_LOCAL_REGEX = "/\([a-zA-Z]*, from userid [0-9]*\)/im";
+	const SENDMAIL_TLS_REGEX = "/\(version=(TLS.*)\)\s+for/im";
+
 	private $message_headers_done = false;
 	private $icon_img;
 	private $rcmail;
-	private $postfix_tls_regex = "/\(using (TLS.*)\) \(/im";
-	private $postfix_local_regex = "/\([a-zA-Z]*, from userid [0-9]*\)/im";
-	private $sendmail_tls_regex = "/\(version=(TLS.*)\)\s+for/im";
 
 	function init()
 	{
@@ -58,11 +59,11 @@ class tls_icon extends rcube_plugin
 				return $p;
 			}
 
-			if (preg_match_all($this->postfix_tls_regex, $Received, $items, PREG_PATTERN_ORDER) ||
-				preg_match_all($this->sendmail_tls_regex, $Received, $items, PREG_PATTERN_ORDER)) {
+			if (preg_match_all(tls_icon::POSTFIX_TLS_REGEX, $Received, $items, PREG_PATTERN_ORDER) ||
+				preg_match_all(tls_icon::SENDMAIL_TLS_REGEX, $Received, $items, PREG_PATTERN_ORDER)) {
 				$data = $items[1][0];
 				$this->icon_img .= '<img class="lock_icon" src="plugins/tls_icon/lock.svg" title="' . htmlentities($data) . '" />';
-			} elseif (preg_match_all($this->postfix_local_regex, $Received, $items, PREG_PATTERN_ORDER)) {
+			} elseif (preg_match_all(tls_icon::POSTFIX_LOCAL_REGEX, $Received, $items, PREG_PATTERN_ORDER)) {
 				$this->icon_img .= '<img class="lock_icon" src="plugins/tls_icon/blue_lock.svg" title="' . $this->gettext('internal') . '" />';
 			} else {
 				// TODO: Mails received from localhost but without TLS are currently flagged insecure

--- a/tls_icon.php
+++ b/tls_icon.php
@@ -4,7 +4,7 @@ class tls_icon extends rcube_plugin
 {
 	const POSTFIX_TLS_REGEX = "/\(using (TLS.*)\) \(/im";
 	const POSTFIX_LOCAL_REGEX = "/\([a-zA-Z]*, from userid [0-9]*\)/im";
-	const SENDMAIL_TLS_REGEX = "/\(version=(TLS.*)\)\s+for/im";
+	const SENDMAIL_TLS_REGEX = "/\(version=(TLS.*)\)(\s+for|;)/im";
 
 	private $message_headers_done = false;
 	private $icon_img;


### PR DESCRIPTION
See issue #11. This is blocked on:

- <s>More tests/confirmation this is working</s> (Appears to be confirmed by @dilyanpalauzov)
- Does Sendmail also log local users in a similar way to Postfix? If so, we need to add a regex for that too.
- <s>Documentation: Is this default Sendmail behaviour, or are there switches for TLS logging, like in Postfix?</s> (No, defaults)