### PR TITLE
Fix leading space when fetch_headers is empty (fixes #15)

### DIFF
--- a/test/TlsIconTest.php
+++ b/test/TlsIconTest.php
@@ -41,10 +41,10 @@ final class TlsIconTest extends TestCase
 	{
 		$o = new tls_icon();
 		$this->assertSame([
-			'fetch_headers' => ' RECEIVED'
+			'fetch_headers' => 'RECEIVED'
 		], $o->storage_init([]));
 		$this->assertSame([
-			'fetch_headers' => ' RECEIVED'
+			'fetch_headers' => 'RECEIVED'
 		], $o->storage_init(['fetch_headers' => null]));
 		$this->assertSame([
 			'fetch_headers' => 'foo bar RECEIVED'

--- a/tls_icon.php
+++ b/tls_icon.php
@@ -42,7 +42,7 @@ class tls_icon extends rcube_plugin
 	public function storage_init($p)
 	{
 		$headers = isset($p['fetch_headers']) ? $p['fetch_headers'] : '';
-		$p['fetch_headers'] = trim($headers) . ' ' . strtoupper('Received');
+		$p['fetch_headers'] = trim(trim($headers) . ' ' . strtoupper('Received'));
 		return $p;
 	}
 


### PR DESCRIPTION
Looks like we got this slightly wrong. The trim was supposed to be there to cut off any trailing or leading spaces, but we accidentally changed that. We did have test coverage for this, but it was the other way around.

Fixes #15 