### PR TITLE
Fix TLS v1.3 on modern Postfix

### DIFF
--- a/test/TlsIconTest.php
+++ b/test/TlsIconTest.php
@@ -33,6 +33,9 @@ final class TlsIconTest extends TestCase
 	/** @var string */
 	private $strStalwartCryptedTlsv13WithCipher = '<img class="lock_icon" src="plugins/tls_icon/lock.svg" title="TLSv1.3 with cipher TLS13_AES_256_GCM_SHA384" />';
 
+	/** @var string */
+	private $strNewPostfixTLSv13 = '<img class="lock_icon" src="plugins/tls_icon/lock.svg" title="TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits) key-exchange ECDHE (secp384r1) server-signature RSA-PSS (4096 bits) server-digest SHA256" />';
+
 	public function testInstance()
 	{
 		$o = new tls_icon();
@@ -195,6 +198,43 @@ final class TlsIconTest extends TestCase
 			]
 		], $headersProcessed);
 	}
+
+	public function testPostfixTLS13NewSyntax()
+	{
+		$header = 'from GVXPR05CU001.outbound.protection.outlook.com (mail-swedencentralazon11023139.outbound.protection.outlook.com [52.101.83.139])
+    (using TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits) key-exchange ECDHE (secp384r1) server-signature RSA-PSS (4096 bits) server-digest SHA256)
+    (No client certificate requested)
+    by example.com with ESMTPS id EXAMPLE
+    for <test@example.com>; Tue, 16 Sep 2025 12:26:17 +0200 (CEST)';
+
+		$o = new tls_icon();
+		$headersProcessed = $o->message_headers([
+			'output' => [
+				'subject' => [
+					'value' => 'Sent to you',
+				],
+			],
+			'headers' => (object)[
+				'others' => [
+					'received' => $header,
+				]
+			]
+		]);
+		$this->assertEquals([
+			'output' => [
+				'subject' => [
+					'value' => 'Sent to you' . $this->strNewPostfixTLSv13,
+					'html' => 1,
+				],
+			],
+			'headers' => (object)[
+				'others' => [
+					'received' => $header,
+				]
+			]
+		], $headersProcessed);
+	}
+
 
 	public function testMessageHeadersMultiFromWithConfig()
 	{

--- a/tls_icon.php
+++ b/tls_icon.php
@@ -2,7 +2,7 @@
 
 class tls_icon extends rcube_plugin
 {
-	const POSTFIX_TLS_REGEX = "/\(using (TLS[^()]+(?:\([^)]+\))?)\)/im";
+	const POSTFIX_TLS_REGEX = "/\(using (TLS(?:[^()]|\([^()]*\))*)\)/im";
 	const POSTFIX_LOCAL_REGEX = "/\([a-zA-Z]*, from userid [0-9]*\)/im";
 	const SENDMAIL_TLS_REGEX = "/\(version=(TLS.*)\)(\s+for|;)/im";
 
@@ -59,8 +59,10 @@ class tls_icon extends rcube_plugin
 				return $p;
 			}
 
-			if (preg_match_all(tls_icon::POSTFIX_TLS_REGEX, $Received, $items, PREG_PATTERN_ORDER) ||
-				preg_match_all(tls_icon::SENDMAIL_TLS_REGEX, $Received, $items, PREG_PATTERN_ORDER)) {
+			if (
+				preg_match_all(tls_icon::POSTFIX_TLS_REGEX, $Received, $items, PREG_PATTERN_ORDER) ||
+				preg_match_all(tls_icon::SENDMAIL_TLS_REGEX, $Received, $items, PREG_PATTERN_ORDER)
+			) {
 				$data = $items[1][0];
 				$this->icon_img .= '<img class="lock_icon" src="plugins/tls_icon/lock.svg" title="' . htmlentities($data) . '" />';
 			} elseif (preg_match_all(tls_icon::POSTFIX_LOCAL_REGEX, $Received, $items, PREG_PATTERN_ORDER)) {


### PR DESCRIPTION
Current versions of Postfix also attach details about the key-exchange, server-signature and server-digest to the header, causing the plugin to display 'unencrypted' on TLS 1.3 messages.

This PR adds an additional test case for those messages and fixes the regex to work for Stalwart, Postfix TLS 1.2, Postfix TLS 1.3 (old test) and this new Postfix TLS 1.3 syntax.