### PR TITLE
Extend `POSTFIX_LOCAL_REGEX` to include mail received from localhost

### DIFF
--- a/test/TlsIconTest.php
+++ b/test/TlsIconTest.php
@@ -199,6 +199,71 @@ final class TlsIconTest extends TestCase
 		], $headersProcessed);
 	}
 
+
+	public function testMessageHeadersInternalLocalhostIPv4()
+	{
+		$o = new tls_icon();
+		$headersProcessed = $o->message_headers([
+			'output' => [
+				'subject' => [
+					'value' => 'Sent to you',
+				],
+			],
+			'headers' => (object)[
+				'others' => [
+					'received' => 'from mail.whitequark.org (localhost [127.0.0.1])
+				by mail.whitequark.org (Postfix) with ESMTP id CDCA2E08B7',
+				]
+			]
+		]);
+		$this->assertEquals([
+			'output' => [
+				'subject' => [
+					'value' => 'Sent to you' . $this->strInternal,
+					'html' => 1,
+				],
+			],
+			'headers' => (object)[
+				'others' => [
+					'received' => 'from mail.whitequark.org (localhost [127.0.0.1])
+				by mail.whitequark.org (Postfix) with ESMTP id CDCA2E08B7',
+				]
+			]
+		], $headersProcessed);
+	}
+
+	public function testMessageHeadersInternalLocalhostIPv6()
+	{
+		$o = new tls_icon();
+		$headersProcessed = $o->message_headers([
+			'output' => [
+				'subject' => [
+					'value' => 'Sent to you',
+				],
+			],
+			'headers' => (object)[
+				'others' => [
+					'received' => 'from mail.whitequark.org (localhost [IPv6:::1])
+				by mail.whitequark.org (Postfix) with ESMTP id CDCA2E08B7',
+				]
+			]
+		]);
+		$this->assertEquals([
+			'output' => [
+				'subject' => [
+					'value' => 'Sent to you' . $this->strInternal,
+					'html' => 1,
+				],
+			],
+			'headers' => (object)[
+				'others' => [
+					'received' => 'from mail.whitequark.org (localhost [IPv6:::1])
+				by mail.whitequark.org (Postfix) with ESMTP id CDCA2E08B7',
+				]
+			]
+		], $headersProcessed);
+	}
+
 	public function testPostfixTLS13NewSyntax()
 	{
 		$header = 'from GVXPR05CU001.outbound.protection.outlook.com (mail-swedencentralazon11023139.outbound.protection.outlook.com [52.101.83.139])
@@ -279,7 +344,7 @@ final class TlsIconTest extends TestCase
 	{
 		$inputHeaders = [
 			'from mail.example.org by mail.example.org with LMTP id pLzoBVClyGIiVgAA3BZZyA (envelope-from <bounces@bounces.example.org>) for <test@example.org>; Fri, 08 Jul 2022 21:44:48 +0000',
-			'from localhost (localhost [127.0.0.1]) by mail.example.org (Postfix) with ESMTP id 0D33249414 for <test@example.org>; Fri,  8 Jul 2022 21:44:48 +0000 (UTC)',
+			'from internalhost (internalhost [192.168.0.1]) by mail.example.org (Postfix) with ESMTP id 0D33249414 for <test@example.org>; Fri,  8 Jul 2022 21:44:48 +0000 (UTC)',
 			'from xxxx-ord.mtasv.net (xxxx-ord.mtasv.net [255.255.255.255]) (using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits)) (No client certificate requested) by mail.example.org (Postfix) with ESMTPS id 73C3B461AF for <test@example.fr>; Fri,  8 Jul 2022 21:44:39 +0000 (UTC)',
 			'by xxxx-ord.mtasv.net id hp2il427tk41 for <test@example.fr>; Fri, 8 Jul 2022 17:44:41 -0400 (envelope-from <bounces@bounces.example.org>)',
 		];

--- a/tls_icon.php
+++ b/tls_icon.php
@@ -3,7 +3,7 @@
 class tls_icon extends rcube_plugin
 {
 	const POSTFIX_TLS_REGEX = "/\(using (TLS(?:[^()]|\([^()]*\))*)\)/im";
-	const POSTFIX_LOCAL_REGEX = "/\([a-zA-Z]*, from userid [0-9]*\)/im";
+	const POSTFIX_LOCAL_REGEX = "/\([a-zA-Z]*, from userid [0-9]*\)|\(localhost \[[^]]+\]\)/im";
 	const SENDMAIL_TLS_REGEX = "/\(version=(TLS.*)\)(\s+for|;)/im";
 
 	private $message_headers_done = false;
@@ -68,7 +68,6 @@ class tls_icon extends rcube_plugin
 			} elseif (preg_match_all(tls_icon::POSTFIX_LOCAL_REGEX, $Received, $items, PREG_PATTERN_ORDER)) {
 				$this->icon_img .= '<img class="lock_icon" src="plugins/tls_icon/blue_lock.svg" title="' . $this->gettext('internal') . '" />';
 			} else {
-				// TODO: Mails received from localhost but without TLS are currently flagged insecure
 				$this->icon_img .= '<img class="lock_icon" src="plugins/tls_icon/unlock.svg" title="' . $this->gettext('unencrypted') . '" />';
 			}
 		}


### PR DESCRIPTION
This matches e.g.:

```
Received: from mail.whitequark.org (localhost [IPv6:::1])
    by mail.whitequark.org (Postfix) with ESMTP id CDCA2E08B7
    for <whitequark@whitequark.org>; Thu, 02 Oct 2025 06:12:47 +0000 (UTC)
```

Thanks for the nice extension!